### PR TITLE
Feat: notification deletion

### DIFF
--- a/client/src/routes/calendar/+page.svelte
+++ b/client/src/routes/calendar/+page.svelte
@@ -659,19 +659,14 @@
             editLocationManual = currentEventPrefs.preview?.location ?? "";
             courseColor = resolved?.color_id ?? "#d50000";
             
-            // If the server explicitly has an empty list of reminder_settings, allow
-            // the UI to show zero notifications so the user can save "no notifications".
-            if (resolved?.reminder_settings) {
+            if (resolved?.reminder_settings && resolved.reminder_settings.length > 0) {
                 //@ts-ignore
-                notifications = resolved.reminder_settings.length > 0
-                    ? resolved.reminder_settings.map(r => ({
-                        time: parseInt(r.time.toString()),
-                        type: r.type,
-                        method: r.method as NotificationMethod
-                    }))
-                    : [];
+                notifications = resolved.reminder_settings.map(r => ({
+                    time: parseInt(r.time.toString()),
+                    type: r.type,
+                    method: r.method as NotificationMethod
+                }));
             } else {
-                // legacy/default behavior: show one default reminder when no data present
                 notifications = [{ time: "30", type: "minutes", method: "notification" }];
             }
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always show a delete button for each reminder and move the add-reminder button outside the list for consistent access.
> 
> - **Frontend**
>   - **Calendar (`client/src/routes/calendar/+page.svelte`)**
>     - Reminder UI: always render per-item delete button (remove length/last-item conditions).
>     - Add-reminder button moved outside the loop to add new reminders consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aed3ea3f6b3abfebc411eca4cebeac1b1c89d12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->