### PR TITLE
feat: add environment switcher for dev/staging/prod

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1180,7 +1180,6 @@
 			"integrity": "sha512-GAAbkWrbRJvysL7+HOWs5v/+TmnRcEQPeED2sUcDFTHpPvRYADEtScL6x8hWuKp0DKauJVaVJLTjQVy9e7cMiw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1220,7 +1219,6 @@
 			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -1596,7 +1594,6 @@
 			"integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -1647,7 +1644,6 @@
 			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.46.2",
 				"@typescript-eslint/types": "8.46.2",
@@ -1865,7 +1861,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2216,7 +2211,6 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3332,7 +3326,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3360,7 +3353,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -3494,7 +3486,6 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -3511,7 +3502,6 @@
 			"integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -3848,7 +3838,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.42.2.tgz",
 			"integrity": "sha512-iSry5jsBHispVczyt9UrBX/1qu3HQ/UyKPAIjqlvlu3o/eUvc+kpyMyRS2O4HLLx4MvLurLGIUOyyP11pyD59g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3942,8 +3931,7 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.16.tgz",
 			"integrity": "sha512-pONL5awpaQX4LN5eiv7moSiSPd/DLDzKVRJz8Q9PgzmAdd1R4307GQS2ZpfiN7ZmekdQrfhZZiSE5jkLR4WNaA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -4031,7 +4019,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -4094,7 +4081,6 @@
 			"integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",

--- a/client/src/lib/environment.ts
+++ b/client/src/lib/environment.ts
@@ -1,0 +1,139 @@
+export type Environment = 'dev' | 'staging' | 'prod';
+
+export interface EnvironmentConfig {
+    name: Environment;
+    displayName: string;
+    baseUrl: string;
+}
+
+export const ENVIRONMENTS: Record<Environment, EnvironmentConfig> = {
+    dev: {
+        name: 'dev',
+        displayName: 'Development',
+        baseUrl: 'https://dev-calendar.witcc.dev'
+    },
+    staging: {
+        name: 'staging',
+        displayName: 'Staging',
+        baseUrl: 'https://staging-calendar.witcc.dev'
+    },
+    prod: {
+        name: 'prod',
+        displayName: 'Production',
+        baseUrl: 'https://server-calendar.witcc.dev'
+    }
+};
+
+interface StoredEnvironmentData {
+    current_environment: Environment;
+    jwt_tokens: Partial<Record<Environment, string>>;
+}
+
+export class EnvironmentManager {
+    private static readonly STORAGE_KEY = 'environment_data';
+
+    /**
+     * Get the current environment data from storage
+     */
+    public static async getEnvironmentData(): Promise<StoredEnvironmentData> {
+        const result = await chrome.storage.local.get(this.STORAGE_KEY);
+        return result[this.STORAGE_KEY] || {
+            current_environment: 'prod',
+            jwt_tokens: {}
+        };
+    }
+
+    /**
+     * Get the current environment
+     */
+    public static async getCurrentEnvironment(): Promise<Environment> {
+        const data = await this.getEnvironmentData();
+        return data.current_environment;
+    }
+
+    /**
+     * Get the current environment config
+     */
+    public static async getCurrentEnvironmentConfig(): Promise<EnvironmentConfig> {
+        const env = await this.getCurrentEnvironment();
+        return ENVIRONMENTS[env];
+    }
+
+    /**
+     * Get the base URL for the current environment
+     */
+    public static async getBaseUrl(): Promise<string> {
+        const config = await this.getCurrentEnvironmentConfig();
+        return config.baseUrl;
+    }
+
+    /**
+     * Get JWT token for a specific environment
+     */
+    public static async getJwtToken(environment?: Environment): Promise<string | undefined> {
+        const data = await this.getEnvironmentData();
+        const env = environment || data.current_environment;
+        return data.jwt_tokens[env];
+    }
+
+    /**
+     * Set JWT token for a specific environment
+     */
+    public static async setJwtToken(token: string, environment?: Environment): Promise<void> {
+        const data = await this.getEnvironmentData();
+        const env = environment || data.current_environment;
+        data.jwt_tokens[env] = token;
+        await chrome.storage.local.set({ [this.STORAGE_KEY]: data });
+    }
+
+    /**
+     * Switch to a new environment
+     * Returns true if JWT exists for the environment, false if onboarding is needed
+     */
+    public static async switchEnvironment(environment: Environment): Promise<boolean> {
+        const data = await this.getEnvironmentData();
+        data.current_environment = environment;
+        await chrome.storage.local.set({ [this.STORAGE_KEY]: data });
+
+        // Return whether JWT exists for this environment
+        return !!data.jwt_tokens[environment];
+    }
+
+    /**
+     * Clear JWT token for a specific environment
+     */
+    public static async clearJwtToken(environment?: Environment): Promise<void> {
+        const data = await this.getEnvironmentData();
+        const env = environment || data.current_environment;
+        delete data.jwt_tokens[env];
+        await chrome.storage.local.set({ [this.STORAGE_KEY]: data });
+    }
+
+    /**
+     * Clear all data (for logout)
+     */
+    public static async clearAllData(): Promise<void> {
+        await chrome.storage.local.remove(this.STORAGE_KEY);
+    }
+
+    /**
+     * Check which environments have JWT tokens
+     */
+    public static async getAuthenticatedEnvironments(): Promise<Environment[]> {
+        const data = await this.getEnvironmentData();
+        return Object.keys(data.jwt_tokens) as Environment[];
+    }
+
+    /**
+     * Migration helper: Import old JWT token format
+     * This helps migrate from the old 'jwt_token' key to the new structure
+     */
+    public static async migrateOldJwtToken(): Promise<void> {
+        const result = await chrome.storage.local.get('jwt_token');
+        if (result.jwt_token) {
+            // Assume old token is for dev environment
+            await this.setJwtToken(result.jwt_token, 'dev');
+            await chrome.storage.local.remove('jwt_token');
+        }
+    }
+}

--- a/client/src/routes/calendar/+page.svelte
+++ b/client/src/routes/calendar/+page.svelte
@@ -236,6 +236,7 @@
 
     async function fetchFromCurrentPage(term: string | undefined): Promise<{ ics_url: string } | undefined> {
         if (!term) return;
+        const baseUrl = await API.baseUrl;
         let tabToUse: any;
         let shouldCloseTab = false;
         try {
@@ -301,7 +302,7 @@
             });
 
             const registrationData = results[0]?.result ?? [];
-            const newData = await fetch(`${API.baseUrl}/process_courses`, {
+            const newData = await fetch(`${baseUrl}/process_courses`, {
                 method: 'POST',
                 body: JSON.stringify(registrationData),
                 headers: {
@@ -365,7 +366,8 @@
     }
 
     async function getEventPerfs(eventId: number) {
-        const res = await fetch(`${API.baseUrl}/meeting_times/${eventId}/preference`, {
+        const baseUrl = await API.baseUrl;
+        const res = await fetch(`${baseUrl}/meeting_times/${eventId}/preference`, {
             method: 'GET',
             headers: {
                 'Authorization': `Bearer ${jwt_token}`
@@ -377,10 +379,11 @@
 
     async function refreshAllEventPrefsForCurrentTerm() {
         if (!selected || !jwt_token || !processedData) return;
+        const baseUrl = await API.baseUrl;
         const ids = Array.from(new Set(processedData.flatMap(c => c.meeting_times.map(mt => mt.id))));
         const responses = await Promise.all(ids.map(async (id) => {
             try {
-                const res = await fetch(`${API.baseUrl}/meeting_times/${id}/preference`, {
+                const res = await fetch(`${baseUrl}/meeting_times/${id}/preference`, {
                     method: 'GET',
                     headers: { 'Authorization': `Bearer ${jwt_token}` }
                 });
@@ -465,6 +468,7 @@
     }
 
     async function saveEventPerfs() {
+        const baseUrl = await API.baseUrl;
         const event_preference: Partial<{
             title_template: string;
             description_template: string;
@@ -527,7 +531,7 @@
         }
 
         const payload = { event_preference };
-        const put = await fetch(`${API.baseUrl}/meeting_times/${activeMeeting?.id}/preference`, {
+        const put = await fetch(`${baseUrl}/meeting_times/${activeMeeting?.id}/preference`, {
             method: 'PUT',
             body: JSON.stringify(payload),
             headers: {

--- a/client/src/routes/gcalendar/+page.svelte
+++ b/client/src/routes/gcalendar/+page.svelte
@@ -50,9 +50,10 @@
     }
 
     async function submitEmail() {
-        const emailToUse = emailToSignInWith || emailToSubmit; 
-        
-        const response = await fetch(`${API.baseUrl}/user/gcal`, {
+        const emailToUse = emailToSignInWith || emailToSubmit;
+        const baseUrl = await API.baseUrl;
+
+        const response = await fetch(`${baseUrl}/user/gcal`, {
             method: 'POST',
             body: JSON.stringify({email: emailToUse}),
             headers: {

--- a/client/src/routes/loading/+page.svelte
+++ b/client/src/routes/loading/+page.svelte
@@ -3,12 +3,15 @@
     import { goto } from '$app/navigation';
     import { LoadingIndicator, Button } from 'm3-svelte';
     import { API } from '$lib/api';
+    import { EnvironmentManager } from '$lib/environment';
     import { snackbar } from 'm3-svelte';
 
     let schoolEmail = $state('');
     let error = $state<string | null>(null);
 
-    onMount(() => {
+    onMount(async () => {
+        // Migrate old JWT token format if needed
+        await EnvironmentManager.migrateOldJwtToken();
         fetchSchoolEmail();
     });
 
@@ -82,7 +85,8 @@
 
     async function signIn() {
         try {
-            const response = await fetch(`${API.baseUrl}/user/onboard`, {
+            const baseUrl = await API.baseUrl;
+            const response = await fetch(`${baseUrl}/user/onboard`, {
                 method: 'POST',
                 body: JSON.stringify({email: schoolEmail}),
                 headers: {
@@ -100,9 +104,7 @@
 
             if (response.ok) {
                 if (data.jwt) {
-                    await chrome.storage.local.set({
-                        jwt_token: data.jwt,
-                    });
+                    await EnvironmentManager.setJwtToken(data.jwt);
                 }
             } else {
                 throw new Error(data.message || 'Server is (probably) down! Please email mayonej@wit.edu!');

--- a/client/static/manifest.json
+++ b/client/static/manifest.json
@@ -30,6 +30,6 @@
   },
   "host_permissions": [
     "https://selfservice.wit.edu/*",
-    "https://heron-selected-literally.ngrok-free.app/*"
+    "https://*.witcc.dev/*"
   ]
 }

--- a/client/static/service-worker.js
+++ b/client/static/service-worker.js
@@ -1,17 +1,25 @@
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'complete' && 
-      tab.url && 
-      tab.url.includes('https://heron-selected-literally.ngrok-free.app/oauth/success')) {
-    
-    console.log('OAuth success page detected');
-    
-    try {
-      await chrome.storage.local.set({
-        oauth_status: 'success',
-      });
-      chrome.tabs.remove(tabId);
-    } catch (error) {
-      console.error('Error during authentication:', error);
+  if (changeInfo.status === 'complete' && tab.url) {
+    // Check if the URL matches any environment's OAuth success page
+    const oauthSuccessPatterns = [
+      'https://dev-calendar.witcc.dev/oauth/success',
+      'https://staging-calendar.witcc.dev/oauth/success',
+      'https://server-calendar.witcc.dev/oauth/success'
+    ];
+
+    const isOAuthSuccess = oauthSuccessPatterns.some(pattern => tab.url.includes(pattern));
+
+    if (isOAuthSuccess) {
+      console.log('OAuth success page detected');
+
+      try {
+        await chrome.storage.local.set({
+          oauth_status: 'success',
+        });
+        chrome.tabs.remove(tabId);
+      } catch (error) {
+        console.error('Error during authentication:', error);
+      }
     }
   }
 });


### PR DESCRIPTION
Implemented a URL switcher that allows users to easily switch between development, staging, and production environments without rebuilding the extension or exposing all URLs in the manifest.

Key changes:
- Created EnvironmentManager to handle per-environment JWT tokens and dynamic URL resolution
- Updated API class to use dynamic baseUrl from current environment
- Added environment switcher UI in Settings with visual indicators for authenticated environments
- Modified manifest.json to use wildcard pattern (*.witcc.dev)
- Updated service-worker.js to handle OAuth redirects for all environments
- Added migration helper for existing JWT tokens
- Each environment maintains separate authentication state

Users can now switch environments from Settings and will be prompted to authenticate if they haven't logged in to that environment yet.