### PR TITLE
fix: use DND API for disable notifications toggle

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -260,6 +260,47 @@ export class API {
         return response.json();
     }
 
+    // Notifications DND (Do Not Disturb) mode
+    public static async getNotificationStatus(): Promise<{ notifications_disabled: boolean; notifications_disabled_until: string | null }> {
+        const baseUrl = await this.getBaseUrl();
+        const token = await this.getJwtToken();
+        const response = await fetch(`${baseUrl}/user/notifications_status`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        return response.json();
+    }
+
+    public static async disableNotifications(duration?: number): Promise<{ notifications_disabled: boolean; notifications_disabled_until: string }> {
+        const baseUrl = await this.getBaseUrl();
+        const token = await this.getJwtToken();
+        const body = duration ? JSON.stringify({ duration }) : undefined;
+        const response = await fetch(`${baseUrl}/user/notifications/disable`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body
+        });
+        return response.json();
+    }
+
+    public static async enableNotifications(): Promise<{ notifications_disabled: boolean; notifications_disabled_until: null }> {
+        const baseUrl = await this.getBaseUrl();
+        const token = await this.getJwtToken();
+        const response = await fetch(`${baseUrl}/user/notifications/enable`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            }
+        });
+        return response.json();
+    }
+
     // Global calendar preferences
     public static async getGlobalCalendarPreference(): Promise<any> {
         const baseUrl = await this.getBaseUrl();

--- a/client/src/lib/components/Settings.svelte
+++ b/client/src/lib/components/Settings.svelte
@@ -57,14 +57,12 @@
             showEnvSwitcher = featureFlags.isEnabledSync('envSwitcher');
             showClearDataButton = featureFlags.isEnabledSync('debugMode');
 
-            // Fetch global calendar preferences for notification toggle
+            // Fetch notification DND status
             try {
-                const globalPref = await API.getGlobalCalendarPreference();
-                if (globalPref && Array.isArray(globalPref.reminder_settings) && globalPref.reminder_settings.length === 0) {
-                    notificationsDisabled = true;
-                }
+                const status = await API.getNotificationStatus();
+                notificationsDisabled = status.notifications_disabled;
             } catch (e) {
-                // Global preference might not exist yet, that's okay
+                // DND status might not be available, that's okay
             }
 
             // Fetch connected accounts
@@ -211,18 +209,16 @@
         notificationsDisabled = disabled;
         try {
             if (disabled) {
-                await API.setGlobalCalendarPreference({ reminder_settings: [] });
+                await API.disableNotifications();
                 snackbar('All notifications disabled', undefined, true);
             } else {
-                await API.setGlobalCalendarPreference({
-                    reminder_settings: [{ time: "30", type: "minutes", method: "notification" }]
-                });
-                snackbar('Default notifications restored (30 min before)', undefined, true);
+                await API.enableNotifications();
+                snackbar('Notifications re-enabled', undefined, true);
             }
         } catch (e) {
             console.error('Failed to update notification settings:', e);
             snackbar('Failed to update notification settings', undefined, true);
-            notificationsDisabled = !disabled; 
+            notificationsDisabled = !disabled;
         }
     }
 


### PR DESCRIPTION
## Summary
- Updates the "Disable All Notifications" toggle to use the new DND (Do Not Disturb) API endpoints
- This properly disables ALL notifications across all preference levels, not just global defaults

## Changes
- Added API methods in `api.ts`:
  - `getNotificationStatus()` - Check if DND is active
  - `disableNotifications(duration?)` - Enable DND mode
  - `enableNotifications()` - Disable DND mode
- Updated `Settings.svelte` to use the new API

## Requires
- Backend PR: WITCodingClub/calendar-backend#226

## Test plan
- [ ] Toggle "Disable All Notifications" ON - verify all event reminders are suppressed
- [ ] Toggle "Disable All Notifications" OFF - verify notifications work again
- [ ] Verify individual event preferences are preserved after toggling DND

Fixes WITCodingClub/calendar-backend#215