### PR TITLE
feat: use consolidated feature flags endpoint

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { EnvironmentManager } from "./environment";
-import type { isProcessed, ProcessedEvents, UniversityCalendarEvent, UniversityEventCategoryWithCount, UserSettings } from "./types";
+import type { FeatureFlagsResponse, isProcessed, ProcessedEvents, UniversityCalendarEvent, UniversityEventCategoryWithCount, UserSettings } from "./types";
 
 export class API {
     private static async getBaseUrl(): Promise<string> {
@@ -32,6 +32,24 @@ export class API {
 
         const data = await response.json();
         return data.is_enabled;
+    }
+
+    public static async getAllFeatureFlags(): Promise<FeatureFlagsResponse> {
+        const baseUrl = await this.getBaseUrl();
+        const token = await this.getJwtToken();
+        const response = await fetch(`${baseUrl}/user/feature_flags`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        });
+
+        if (!response.ok) {
+            console.error('Feature flags API error:', response.status, response.statusText);
+            throw new Error(`Failed to fetch feature flags: ${response.status}`);
+        }
+
+        return response.json();
     }
 
     public static async getTerms() {

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -18,12 +18,18 @@ const FEATURE_FLAGS = [
     "v1",
     "v2",
     "debugMode",
-    "envSwitcher"
-]
+    "envSwitcher",
+    "finalsRetroactive",
+    "bypassRateLimits"
+] as const;
 
 interface FeatureFlagEnabled {
     feature_name: string;
     is_enabled: boolean;
+}
+
+interface FeatureFlagsResponse {
+    feature_flags: Record<string, boolean>;
 }
 
 interface Location {
@@ -225,6 +231,6 @@ export {
     FEATURE_FLAGS,
     type Building,
     type CalendarConfig, type Course, type CurrentTerm, type DayItem,
-    type EventPreferences, type GetPreferencesResponse, type isProcessed, type Location,
+    type EventPreferences, type FeatureFlagsResponse, type GetPreferencesResponse, type isProcessed, type Location,
     type MeetingTime, type NextTerm, type NotificationMethod, type NotificationSetting, type NotificationType, type Preview, type ProcessedEvents, type Professor, type ReminderSettings, type ResolvedData, type ResponseData, type TemplateVariables, type Term, type TermResponse, type UniversityCalendarEvent, type UniversityEventCategory, type UniversityEventCategoryWithCount, type UserSettings
 };


### PR DESCRIPTION
## Summary
- Update frontend to use new `GET /api/user/feature_flags` endpoint
- Reduces server requests from 6 individual flag checks to 1 consolidated request
- Add missing feature flags (`finalsRetroactive`, `bypassRateLimits`) to match backend

## Changes
- **API**: Add `getAllFeatureFlags()` method to fetch all flags in one request
- **Service**: Update `FeatureFlagsService._fetchFlags()` to use new consolidated endpoint
- **Types**: Add `FeatureFlagsResponse` type and update `FEATURE_FLAGS` array
- **Performance**: Single API call instead of parallel Promise.all with 6 individual requests

## Impact
- Reduces network requests from 6 to 1 when loading feature flags
- Improves extension/app startup performance
- Better error handling with single failure point

## Dependencies
Requires backend PR: https://github.com/WITCodingClub/calendar-backend/pull/317

Related to WITCodingClub/calendar-backend#275